### PR TITLE
Make sure to populate the multidat error back up the stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function Multidat (db, cb) {
   assert.equal(typeof cb, 'function', 'multidat: cb should be type function')
 
   multidrive(db, createArchive, closeArchive, function (err, drive) {
-    if (err) return cb(explain(err, 'multidat: error creating multidrive'))
+    if (err) return cb(err)
     var multidat = {
       readManifest: readManifest,
       create: create,


### PR DESCRIPTION
I was getting a module mismatch error but it was hidden under the sheets. I think in general it's probably good to propagate fatal errors like this up the stack 