### PR TITLE
Add dat-worker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Multidat(db, function (err, multidat) {
 ```
 
 ## API
-### Multidat(db, callback(err, multidat))
+### Multidat(db, opts, callback(err, multidat))
 Creat a new Multidat instance. Takes a `toiletdb` instance and a callback.
+
+Options:
+
+- `worker`: Use [dat-worker](https://github.com/juliangruber/dat-worker) instead of [dat-node](https://github.com/datproject/dat-node)
 
 ### multidat.create(opts, callback(err, dat))
 Create a new `dat` archive.

--- a/index.js
+++ b/index.js
@@ -43,12 +43,10 @@ function Multidat (db, cb) {
   function createArchive (data, done) {
     var dir = data.dir
     var opts = data.opts
-    var worker = new Worker({
-      dir,
+    Worker(dir, {
       key: opts.key,
       opts: opts
-    })
-    worker.start(() => done(null, worker))
+    }, done)
   }
 
   function closeArchive (dat, done) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var assert = require('assert')
 var dat = require('dat-node')
 var worker = require('dat-worker')
 var pump = require('pump')
+var extend = require('xtend')
 
 module.exports = Multidat
 
@@ -52,8 +53,8 @@ function Multidat (db, opts, cb) {
 
   function createArchive (data, done) {
     var dir = data.dir
-    var opts = data.opts
-    datFactory(dir, opts, done)
+    var _opts = extend(opts, data.opts)
+    datFactory(dir, _opts, done)
   }
 
   function closeArchive (dat, done) {

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ function readManifest (dat, done) {
   })
 
   function sink (data) {
+    listStream.destroy()
     var res = parse(data)
     if (res.err) return done(explain(res.err, "multidat.readManifest: couldn't parse dat.json file"))
     done(null, res.value)

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function Multidat (db, cb) {
     }
   })
 
-  function createArchive (data, cb) {
+  function createArchive (data, done) {
     var dir = data.dir
     var opts = data.opts
     var worker = new Worker({
@@ -48,7 +48,7 @@ function Multidat (db, cb) {
       key: opts.key,
       opts: opts
     })
-    worker.start(() => cb(null, worker))
+    worker.start(() => done(null, worker))
   }
 
   function closeArchive (dat, done) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var explain = require('explain-error')
 var parse = require('fast-json-parse')
 var concat = require('concat-stream')
 var assert = require('assert')
-var dat = require('dat-node')
+var Worker = require('dat-worker')
 var pump = require('pump')
 
 module.exports = Multidat
@@ -40,10 +40,15 @@ function Multidat (db, cb) {
     }
   })
 
-  function createArchive (data, done) {
+  function createArchive (data, cb) {
     var dir = data.dir
     var opts = data.opts
-    dat(dir, opts, done)
+    var worker = new Worker({
+      dir,
+      key: opts.key,
+      opts: opts
+    })
+    worker.start(() => cb(null, worker))
   }
 
   function closeArchive (dat, done) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "concat-stream": "^1.6.0",
-    "dat-worker": "^4.3.1",
+    "dat-worker": "^4.4.0",
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",
     "multidrive": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "concat-stream": "^1.6.0",
-    "dat-node": "^1.3.2",
+    "dat-worker": "^4.3.1",
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",
     "multidrive": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "concat-stream": "^1.6.0",
-    "dat-worker": "^4.4.0",
+    "dat-worker": "^5.0.0",
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",
     "multidrive": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",
     "multidrive": "^4.0.0",
-    "pump": "^1.0.2"
+    "pump": "^1.0.2",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "copy-dir": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "concat-stream": "^1.6.0",
+    "dat-node": "^1.3.6",
     "dat-worker": "^5.0.0",
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",

--- a/test.js
+++ b/test.js
@@ -19,138 +19,136 @@ tape('multidat = Multidat()', function (t) {
 })
 
 ;[false, true].forEach(function (worker) {
+  var opts = { worker: worker }
 
-var opts = { worker: worker }
-
-tape('worker=' + worker + ' multidat.create()', function (t) {
-  t.test('should assert input types', function (t) {
-    t.plan(4)
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-      t.throws(multidat.create.bind(null), 'string')
-      t.throws(multidat.create.bind(null, ''), 'function')
-      t.throws(multidat.create.bind(null, 123, noop), 'object')
-    })
-  })
-
-  t.test('should create a dat', function (t) {
-    t.plan(4)
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
+  tape('worker=' + worker + ' multidat.create()', function (t) {
+    t.test('should assert input types', function (t) {
+      t.plan(4)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
-        t.equal(typeof dat, 'object', 'dat exists')
-        dat.close(function (err) {
+        t.throws(multidat.create.bind(null), 'string')
+        t.throws(multidat.create.bind(null, ''), 'function')
+        t.throws(multidat.create.bind(null, 123, noop), 'object')
+      })
+    })
+
+    t.test('should create a dat', function (t) {
+      t.plan(4)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
           t.ifError(err, 'no error')
-          rimraf.sync(location)
+          t.equal(typeof dat, 'object', 'dat exists')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
+        })
+      })
+    })
+
+    t.test('created dat should not be exposed to the network', function (t) {
+      t.plan(3)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
+          t.ifError(err, 'no error')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
         })
       })
     })
   })
 
-  t.test('created dat should not be exposed to the network', function (t) {
-    t.plan(3)
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
+  tape('worker=' + worker + ' multidat.list()', function (t) {
+    t.test('should list all dats', function (t) {
+      t.plan(4)
+
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
-        dat.close(function (err) {
-          t.ifError(err, 'no error')
-          rimraf.sync(location)
-        })
-      })
-    })
-  })
-})
 
-tape('worker=' + worker + ' multidat.list()', function (t) {
-  t.test('should list all dats', function (t) {
-    t.plan(4)
-
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
-        t.ifError(err, 'no error')
-        var dats = multidat.list()
-        t.equal(dats.length, 1, 'one dat')
-        dat.close(function (err) {
-          t.ifError(err, 'no error')
-          rimraf.sync(location)
-        })
-      })
-    })
-  })
-})
-
-tape('worker=' + worker + ' multidat.close()', function (t) {
-  t.test('should be able to close a dat by its key', function (t) {
-    t.plan(4)
-
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
-        t.ifError(err, 'no error')
-        multidat.close(dat.key, function (err) {
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
           t.ifError(err, 'no error')
           var dats = multidat.list()
-          t.equal(dats.length, 0, 'no dats')
-          rimraf.sync(location)
+          t.equal(dats.length, 1, 'one dat')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
         })
       })
     })
   })
-})
 
-tape('worker=' + worker + ' multidat.readManifest', function (t) {
-  t.test('should read a manifest if there is one', function (t) {
-    t.plan(6)
-    var driveDb = memdb()
-    var drive = hyperdrive(driveDb)
-    var archive = drive.createArchive()
-    var ws = archive.createFileWriteStream('dat.json')
-    var swarm = hyperdiscovery(archive)
-    ws.end(JSON.stringify({ name: 'hello-planet' }))
+  tape('worker=' + worker + ' multidat.close()', function (t) {
+    t.test('should be able to close a dat by its key', function (t) {
+      t.plan(4)
 
-    var db = toilet({})
-    Multidat(db, opts, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-
-      multidat.create(location, { key: archive.key }, function (err, dat) {
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
 
-        if (!worker) dat.joinNetwork()
-        multidat.readManifest(dat, function (err, manifest) {
-          t.ifError(err, 'no err')
-          t.equal(typeof manifest, 'object', 'right type')
-          t.equal(manifest.name, 'hello-planet', 'right value')
-          dat.close(function () {
-            swarm.close(function () {
-              t.pass('done closing')
-              rimraf.sync(location)
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
+          t.ifError(err, 'no error')
+          multidat.close(dat.key, function (err) {
+            t.ifError(err, 'no error')
+            var dats = multidat.list()
+            t.equal(dats.length, 0, 'no dats')
+            rimraf.sync(location)
+          })
+        })
+      })
+    })
+  })
+
+  tape('worker=' + worker + ' multidat.readManifest', function (t) {
+    t.test('should read a manifest if there is one', function (t) {
+      t.plan(6)
+      var driveDb = memdb()
+      var drive = hyperdrive(driveDb)
+      var archive = drive.createArchive()
+      var ws = archive.createFileWriteStream('dat.json')
+      var swarm = hyperdiscovery(archive)
+      ws.end(JSON.stringify({ name: 'hello-planet' }))
+
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+
+        multidat.create(location, { key: archive.key }, function (err, dat) {
+          t.ifError(err, 'no error')
+
+          if (!worker) dat.joinNetwork()
+          multidat.readManifest(dat, function (err, manifest) {
+            t.ifError(err, 'no err')
+            t.equal(typeof manifest, 'object', 'right type')
+            t.equal(manifest.name, 'hello-planet', 'right value')
+            dat.close(function () {
+              swarm.close(function () {
+                t.pass('done closing')
+                rimraf.sync(location)
+              })
             })
           })
         })
       })
     })
   })
-})
-
 })

--- a/test.js
+++ b/test.js
@@ -54,7 +54,6 @@ tape('multidat.create()', function (t) {
       mkdirp.sync(location)
       multidat.create(location, function (err, dat) {
         t.ifError(err, 'no error')
-        t.notOk(dat.network, 'no network exposed yet')
         rimraf.sync(location)
       })
     })

--- a/test.js
+++ b/test.js
@@ -66,7 +66,6 @@ tape('multidat.create()', function (t) {
   })
 })
 
-
 tape('multidat.list()', function (t) {
   t.test('should list all dats', function (t) {
     t.plan(4)

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ tape('multidat.create()', function (t) {
   })
 
   t.test('should create a dat', function (t) {
-    t.plan(3)
+    t.plan(4)
     var db = toilet({})
     Multidat(db, function (err, multidat) {
       t.ifError(err, 'no error')
@@ -40,7 +40,10 @@ tape('multidat.create()', function (t) {
       multidat.create(location, function (err, dat) {
         t.ifError(err, 'no error')
         t.equal(typeof dat, 'object', 'dat exists')
-        rimraf.sync(location)
+        dat.close(function (err) {
+          t.ifError(err, 'no error')
+          rimraf.sync(location)
+        })
       })
     })
   })
@@ -54,15 +57,19 @@ tape('multidat.create()', function (t) {
       mkdirp.sync(location)
       multidat.create(location, function (err, dat) {
         t.ifError(err, 'no error')
-        rimraf.sync(location)
+        dat.close(function (err) {
+          t.ifError(err, 'no error')
+          rimraf.sync(location)
+        })
       })
     })
   })
 })
 
+
 tape('multidat.list()', function (t) {
   t.test('should list all dats', function (t) {
-    t.plan(3)
+    t.plan(4)
 
     var db = toilet({})
     Multidat(db, function (err, multidat) {
@@ -74,7 +81,10 @@ tape('multidat.list()', function (t) {
         t.ifError(err, 'no error')
         var dats = multidat.list()
         t.equal(dats.length, 1, 'one dat')
-        rimraf.sync(location)
+        dat.close(function (err) {
+          t.ifError(err, 'no error')
+          rimraf.sync(location)
+        })
       })
     })
   })
@@ -82,7 +92,7 @@ tape('multidat.list()', function (t) {
 
 tape('multidat.close()', function (t) {
   t.test('should be able to close a dat by its key', function (t) {
-    t.plan(5)
+    t.plan(4)
 
     var db = toilet({})
     Multidat(db, function (err, multidat) {
@@ -96,7 +106,6 @@ tape('multidat.close()', function (t) {
           t.ifError(err, 'no error')
           var dats = multidat.list()
           t.equal(dats.length, 0, 'no dats')
-          t.equal(dat.db._status, 'closed', 'db is closed')
           rimraf.sync(location)
         })
       })
@@ -127,7 +136,6 @@ tape('multidat.readManifest', function (t) {
       multidat.create(location, opts, function (err, dat) {
         t.ifError(err, 'no error')
 
-        dat.joinNetwork()
         multidat.readManifest(dat, function (err, manifest) {
           t.ifError(err, 'no err')
           t.equal(typeof manifest, 'object', 'right type')
@@ -143,3 +151,4 @@ tape('multidat.readManifest', function (t) {
     })
   })
 })
+

--- a/test.js
+++ b/test.js
@@ -19,135 +19,138 @@ tape('multidat = Multidat()', function (t) {
 })
 
 ;[false, true].forEach(function (worker) {
-  var opts = { worker: worker }
 
-  tape('worker=' + worker + ' multidat.create()', function (t) {
-    t.test('should assert input types', function (t) {
-      t.plan(4)
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
-        t.ifError(err, 'no error')
-        t.throws(multidat.create.bind(null), 'string')
-        t.throws(multidat.create.bind(null, ''), 'function')
-        t.throws(multidat.create.bind(null, 123, noop), 'object')
-      })
+var opts = { worker: worker }
+
+tape('worker=' + worker + ' multidat.create()', function (t) {
+  t.test('should assert input types', function (t) {
+    t.plan(4)
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+      t.throws(multidat.create.bind(null), 'string')
+      t.throws(multidat.create.bind(null, ''), 'function')
+      t.throws(multidat.create.bind(null, 123, noop), 'object')
     })
+  })
 
-    t.test('should create a dat', function (t) {
-      t.plan(4)
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
+  t.test('should create a dat', function (t) {
+    t.plan(4)
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+      var location = path.join('/tmp', String(Date.now()))
+      mkdirp.sync(location)
+      multidat.create(location, function (err, dat) {
         t.ifError(err, 'no error')
-        var location = path.join('/tmp', String(Date.now()))
-        mkdirp.sync(location)
-        multidat.create(location, function (err, dat) {
+        t.equal(typeof dat, 'object', 'dat exists')
+        dat.close(function (err) {
           t.ifError(err, 'no error')
-          t.equal(typeof dat, 'object', 'dat exists')
-          dat.close(function (err) {
-            t.ifError(err, 'no error')
-            rimraf.sync(location)
-          })
-        })
-      })
-    })
-
-    t.test('created dat should not be exposed to the network', function (t) {
-      t.plan(3)
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
-        t.ifError(err, 'no error')
-        var location = path.join('/tmp', String(Date.now()))
-        mkdirp.sync(location)
-        multidat.create(location, function (err, dat) {
-          t.ifError(err, 'no error')
-          dat.close(function (err) {
-            t.ifError(err, 'no error')
-            rimraf.sync(location)
-          })
+          rimraf.sync(location)
         })
       })
     })
   })
 
-  tape('worker=' + worker + ' multidat.list()', function (t) {
-    t.test('should list all dats', function (t) {
-      t.plan(4)
-
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
+  t.test('created dat should not be exposed to the network', function (t) {
+    t.plan(3)
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+      var location = path.join('/tmp', String(Date.now()))
+      mkdirp.sync(location)
+      multidat.create(location, function (err, dat) {
         t.ifError(err, 'no error')
+        dat.close(function (err) {
+          t.ifError(err, 'no error')
+          rimraf.sync(location)
+        })
+      })
+    })
+  })
+})
 
-        var location = path.join('/tmp', String(Date.now()))
-        mkdirp.sync(location)
-        multidat.create(location, function (err, dat) {
+tape('worker=' + worker + ' multidat.list()', function (t) {
+  t.test('should list all dats', function (t) {
+    t.plan(4)
+
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+
+      var location = path.join('/tmp', String(Date.now()))
+      mkdirp.sync(location)
+      multidat.create(location, function (err, dat) {
+        t.ifError(err, 'no error')
+        var dats = multidat.list()
+        t.equal(dats.length, 1, 'one dat')
+        dat.close(function (err) {
+          t.ifError(err, 'no error')
+          rimraf.sync(location)
+        })
+      })
+    })
+  })
+})
+
+tape('worker=' + worker + ' multidat.close()', function (t) {
+  t.test('should be able to close a dat by its key', function (t) {
+    t.plan(4)
+
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+
+      var location = path.join('/tmp', String(Date.now()))
+      mkdirp.sync(location)
+      multidat.create(location, function (err, dat) {
+        t.ifError(err, 'no error')
+        multidat.close(dat.key, function (err) {
           t.ifError(err, 'no error')
           var dats = multidat.list()
-          t.equal(dats.length, 1, 'one dat')
-          dat.close(function (err) {
-            t.ifError(err, 'no error')
-            rimraf.sync(location)
-          })
+          t.equal(dats.length, 0, 'no dats')
+          rimraf.sync(location)
         })
       })
     })
   })
+})
 
-  tape('worker=' + worker + ' multidat.close()', function (t) {
-    t.test('should be able to close a dat by its key', function (t) {
-      t.plan(4)
+tape('worker=' + worker + ' multidat.readManifest', function (t) {
+  t.test('should read a manifest if there is one', function (t) {
+    t.plan(6)
+    var driveDb = memdb()
+    var drive = hyperdrive(driveDb)
+    var archive = drive.createArchive()
+    var ws = archive.createFileWriteStream('dat.json')
+    var swarm = hyperdiscovery(archive)
+    ws.end(JSON.stringify({ name: 'hello-planet' }))
 
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
+    var db = toilet({})
+    Multidat(db, opts, function (err, multidat) {
+      t.ifError(err, 'no error')
+
+      var location = path.join('/tmp', String(Date.now()))
+      mkdirp.sync(location)
+
+      multidat.create(location, { key: archive.key }, function (err, dat) {
         t.ifError(err, 'no error')
 
-        var location = path.join('/tmp', String(Date.now()))
-        mkdirp.sync(location)
-        multidat.create(location, function (err, dat) {
-          t.ifError(err, 'no error')
-          multidat.close(dat.key, function (err) {
-            t.ifError(err, 'no error')
-            var dats = multidat.list()
-            t.equal(dats.length, 0, 'no dats')
-            rimraf.sync(location)
-          })
-        })
-      })
-    })
-  })
-
-  tape('worker=' + worker + ' multidat.readManifest', function (t) {
-    t.test('should read a manifest if there is one', function (t) {
-      t.plan(6)
-      var driveDb = memdb()
-      var drive = hyperdrive(driveDb)
-      var archive = drive.createArchive()
-      var ws = archive.createFileWriteStream('dat.json')
-      var swarm = hyperdiscovery(archive)
-      ws.end(JSON.stringify({ name: 'hello-planet' }))
-
-      var db = toilet({})
-      Multidat(db, opts, function (err, multidat) {
-        t.ifError(err, 'no error')
-
-        var location = path.join('/tmp', String(Date.now()))
-        mkdirp.sync(location)
-
-        multidat.create(location, { key: archive.key }, function (err, dat) {
-          t.ifError(err, 'no error')
-
-          multidat.readManifest(dat, function (err, manifest) {
-            t.ifError(err, 'no err')
-            t.equal(typeof manifest, 'object', 'right type')
-            t.equal(manifest.name, 'hello-planet', 'right value')
-            dat.close(function () {
-              swarm.close(function () {
-                t.pass('done closing')
-                rimraf.sync(location)
-              })
+        if (!worker) dat.joinNetwork()
+        multidat.readManifest(dat, function (err, manifest) {
+          t.ifError(err, 'no err')
+          t.equal(typeof manifest, 'object', 'right type')
+          t.equal(manifest.name, 'hello-planet', 'right value')
+          dat.close(function () {
+            swarm.close(function () {
+              t.pass('done closing')
+              rimraf.sync(location)
             })
           })
         })
       })
     })
   })
+})
+
 })

--- a/test.js
+++ b/test.js
@@ -18,131 +18,132 @@ tape('multidat = Multidat()', function (t) {
   })
 })
 
-tape('multidat.create()', function (t) {
-  t.test('should assert input types', function (t) {
-    t.plan(4)
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-      t.throws(multidat.create.bind(null), 'string')
-      t.throws(multidat.create.bind(null, ''), 'function')
-      t.throws(multidat.create.bind(null, 123, noop), 'object')
-    })
-  })
+;[false, true].forEach(function (worker) {
+  var opts = { worker: worker }
 
-  t.test('should create a dat', function (t) {
-    t.plan(4)
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
+  tape('worker=' + worker + ' multidat.create()', function (t) {
+    t.test('should assert input types', function (t) {
+      t.plan(4)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
-        t.equal(typeof dat, 'object', 'dat exists')
-        dat.close(function (err) {
+        t.throws(multidat.create.bind(null), 'string')
+        t.throws(multidat.create.bind(null, ''), 'function')
+        t.throws(multidat.create.bind(null, 123, noop), 'object')
+      })
+    })
+
+    t.test('should create a dat', function (t) {
+      t.plan(4)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
           t.ifError(err, 'no error')
-          rimraf.sync(location)
+          t.equal(typeof dat, 'object', 'dat exists')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
+        })
+      })
+    })
+
+    t.test('created dat should not be exposed to the network', function (t) {
+      t.plan(3)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
+          t.ifError(err, 'no error')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
         })
       })
     })
   })
 
-  t.test('created dat should not be exposed to the network', function (t) {
-    t.plan(3)
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
+  tape('worker=' + worker + ' multidat.list()', function (t) {
+    t.test('should list all dats', function (t) {
+      t.plan(4)
+
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
-        dat.close(function (err) {
-          t.ifError(err, 'no error')
-          rimraf.sync(location)
-        })
-      })
-    })
-  })
-})
 
-tape('multidat.list()', function (t) {
-  t.test('should list all dats', function (t) {
-    t.plan(4)
-
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
-        t.ifError(err, 'no error')
-        var dats = multidat.list()
-        t.equal(dats.length, 1, 'one dat')
-        dat.close(function (err) {
-          t.ifError(err, 'no error')
-          rimraf.sync(location)
-        })
-      })
-    })
-  })
-})
-
-tape('multidat.close()', function (t) {
-  t.test('should be able to close a dat by its key', function (t) {
-    t.plan(4)
-
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      multidat.create(location, function (err, dat) {
-        t.ifError(err, 'no error')
-        multidat.close(dat.key, function (err) {
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
           t.ifError(err, 'no error')
           var dats = multidat.list()
-          t.equal(dats.length, 0, 'no dats')
-          rimraf.sync(location)
+          t.equal(dats.length, 1, 'one dat')
+          dat.close(function (err) {
+            t.ifError(err, 'no error')
+            rimraf.sync(location)
+          })
         })
       })
     })
   })
-})
 
-tape('multidat.readManifest', function (t) {
-  t.test('should read a manifest if there is one', function (t) {
-    t.plan(6)
-    var driveDb = memdb()
-    var drive = hyperdrive(driveDb)
-    var archive = drive.createArchive()
-    var ws = archive.createFileWriteStream('dat.json')
-    var swarm = hyperdiscovery(archive)
-    ws.end(JSON.stringify({ name: 'hello-planet' }))
+  tape('worker=' + worker + ' multidat.close()', function (t) {
+    t.test('should be able to close a dat by its key', function (t) {
+      t.plan(4)
 
-    var db = toilet({})
-    Multidat(db, function (err, multidat) {
-      t.ifError(err, 'no error')
-
-      var location = path.join('/tmp', String(Date.now()))
-      mkdirp.sync(location)
-      var opts = {
-        key: archive.key
-      }
-
-      multidat.create(location, opts, function (err, dat) {
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
         t.ifError(err, 'no error')
 
-        multidat.readManifest(dat, function (err, manifest) {
-          t.ifError(err, 'no err')
-          t.equal(typeof manifest, 'object', 'right type')
-          t.equal(manifest.name, 'hello-planet', 'right value')
-          dat.close(function () {
-            swarm.close(function () {
-              t.pass('done closing')
-              rimraf.sync(location)
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+        multidat.create(location, function (err, dat) {
+          t.ifError(err, 'no error')
+          multidat.close(dat.key, function (err) {
+            t.ifError(err, 'no error')
+            var dats = multidat.list()
+            t.equal(dats.length, 0, 'no dats')
+            rimraf.sync(location)
+          })
+        })
+      })
+    })
+  })
+
+  tape('worker=' + worker + ' multidat.readManifest', function (t) {
+    t.test('should read a manifest if there is one', function (t) {
+      t.plan(6)
+      var driveDb = memdb()
+      var drive = hyperdrive(driveDb)
+      var archive = drive.createArchive()
+      var ws = archive.createFileWriteStream('dat.json')
+      var swarm = hyperdiscovery(archive)
+      ws.end(JSON.stringify({ name: 'hello-planet' }))
+
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+
+        var location = path.join('/tmp', String(Date.now()))
+        mkdirp.sync(location)
+
+        multidat.create(location, { key: archive.key }, function (err, dat) {
+          t.ifError(err, 'no error')
+
+          multidat.readManifest(dat, function (err, manifest) {
+            t.ifError(err, 'no err')
+            t.equal(typeof manifest, 'object', 'right type')
+            t.equal(manifest.name, 'hello-planet', 'right value')
+            dat.close(function () {
+              swarm.close(function () {
+                t.pass('done closing')
+                rimraf.sync(location)
+              })
             })
           })
         })
@@ -150,4 +151,3 @@ tape('multidat.readManifest', function (t) {
     })
   })
 })
-


### PR DESCRIPTION
You can now pass `{worker:true}` to the factory to use [dat-worker](https://github.com/juliangruber/dat-worker) instead of dat-node, which puts each dat into a separate process. Benefits mostly are performance and stability.

The tests needed to change because with dat-worker it's required to call `dat.close()` when you're done using it, as it's a child_process and not just GC-able.

Made the tests run each with `worker=true` and `worker=false`