### PR TITLE
add { dat } option and remove { worker }

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var parse = require('fast-json-parse')
 var concat = require('concat-stream')
 var assert = require('assert')
 var dat = require('dat-node')
-var worker = require('dat-worker')
 var pump = require('pump')
 var extend = require('xtend')
 
@@ -19,9 +18,7 @@ function Multidat (db, opts, cb) {
   assert.equal(typeof db, 'object', 'multidat: db should be type object')
   assert.equal(typeof cb, 'function', 'multidat: cb should be type function')
 
-  var datFactory = (opts.worker)
-    ? worker
-    : dat
+  var datFactory = opts.dat || dat
 
   multidrive(db, createArchive, closeArchive, function (err, drive) {
     if (err) return cb(explain(err, 'multidat: error creating multidrive'))

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "concat-stream": "^1.6.0",
     "dat-node": "^1.3.6",
-    "dat-worker": "^5.0.0",
     "explain-error": "^1.0.3",
     "fast-json-parse": "^1.0.2",
     "multidrive": "^4.0.0",
@@ -21,6 +20,7 @@
   },
   "devDependencies": {
     "copy-dir": "^0.3.0",
+    "dat-worker": "^5.0.0",
     "dependency-check": "^2.7.0",
     "hyperdiscovery": "^1.1.0",
     "hyperdrive": "^7.13.1",

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var hyperdiscovery = require('hyperdiscovery')
 var toilet = require('toiletdb/inmemory')
 var hyperdrive = require('hyperdrive')
+var datWorker = require('dat-worker')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var memdb = require('memdb')
@@ -19,7 +20,7 @@ tape('multidat = Multidat()', function (t) {
 })
 
 ;[false, true].forEach(function (worker) {
-  var opts = { worker: worker }
+  var opts = { dat: worker && datWorker }
 
   tape('worker=' + worker + ' multidat.create()', function (t) {
     t.test('should assert input types', function (t) {


### PR DESCRIPTION
It's confusing to have to reinstall `multidat` to get new `dat-worker` fixes, instead just have `dat-worker` be a peer dependency.