### PR TITLE
add errors to dat list instead of failing completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,21 @@ Multidat(db, function (err, multidat) {
 })
 ```
 
+## Error handling
+If there is an error initializing a dat, instead of the whole process failing, an error object with attached `.dir` property will be pushed into the list of dats instead. That means when consuming `multidat.list()`, you should check for errors:
+
+```js
+var dats = multidat.list()
+dats.forEach(function (dat) {
+  if (dat instanceof Error) {
+    var err = dat
+    console.log('failed to initialize dat in %s: %s', err.dir, err.message)
+  }
+})
+```
+
+This way you can decide for yourself whether an individual initialization failure should cause the whole process to fail or not.
+
 ## API
 ### Multidat(db, opts, callback(err, multidat))
 Creat a new Multidat instance. Takes a `toiletdb` instance and a callback.

--- a/index.js
+++ b/index.js
@@ -52,10 +52,13 @@ function Multidat (db, opts, cb) {
   function createArchive (data, done) {
     var dir = data.dir
     var _opts = extend(opts, data.opts)
-    datFactory(dir, _opts, done)
+    datFactory(dir, _opts, function (err, dat) {
+      done(null, err || dat)
+    })
   }
 
   function closeArchive (dat, done) {
+    if (dat instanceof Error) return done()
     if (dat._listStreams) {
       dat._listStreams.forEach(function (listStream) {
         listStream.destroy()

--- a/index.js
+++ b/index.js
@@ -59,7 +59,6 @@ function Multidat (db, opts, cb) {
   }
 
   function closeArchive (dat, done) {
-    if (dat instanceof Error) return done()
     if (dat._listStreams) {
       dat._listStreams.forEach(function (listStream) {
         listStream.destroy()

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ function Multidat (db, opts, cb) {
     var dir = data.dir
     var _opts = extend(opts, data.opts)
     datFactory(dir, _opts, function (err, dat) {
+      if (err) err.dir = dir
       done(null, err || dat)
     })
   }


### PR DESCRIPTION
this is required for https://github.com/datproject/dat-desktop/issues/284

This way you can check `dat instanceof Error` and render UI properly.

This is a breaking change.