### PR TITLE
Fix (error) in create

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,13 @@ function Multidat (db, opts, cb) {
         dir: dir,
         opts: opts
       }
-      drive.create(data, cb)
+      drive.create(data, function (err, dat) {
+        if (dat instanceof Error) {
+          err = dat
+          dat = null
+        }
+        cb(err, dat)
+      })
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "copy-dir": "^0.3.0",
-    "dat-worker": "^5.0.0",
+    "dat-worker": "^7.0.6",
     "dependency-check": "^2.7.0",
     "hyperdiscovery": "^1.1.0",
     "hyperdrive": "^7.13.1",

--- a/test.js
+++ b/test.js
@@ -136,7 +136,7 @@ tape('multidat = Multidat()', function (t) {
         multidat.create(location, { key: archive.key }, function (err, dat) {
           t.ifError(err, 'no error')
 
-          if (!worker) dat.joinNetwork()
+          dat.joinNetwork()
           multidat.readManifest(dat, function (err, manifest) {
             t.ifError(err, 'no err')
             t.equal(typeof manifest, 'object', 'right type')
@@ -171,7 +171,7 @@ tape('multidat = Multidat()', function (t) {
         multidat.create(location, { key: archive.key }, function (err, dat) {
           t.ifError(err, 'no error')
 
-          if (!worker) dat.joinNetwork()
+          dat.joinNetwork()
           var updates = multidat.readManifest(dat)
           updates.on('error', function (err) {
             t.ifError(err, 'no err')
@@ -210,7 +210,7 @@ tape('multidat = Multidat()', function (t) {
         multidat.create(location, { key: archive.key }, function (err, dat) {
           t.ifError(err, 'no error')
 
-          if (!worker) dat.joinNetwork()
+          dat.joinNetwork()
           var updates = multidat.readManifest(dat)
           updates.on('error', function (err) {
             t.ifError(err, 'no err')

--- a/test.js
+++ b/test.js
@@ -68,6 +68,18 @@ tape('multidat = Multidat()', function (t) {
         })
       })
     })
+
+    t.test('creation error', function (t) {
+      t.plan(3)
+      var db = toilet({})
+      Multidat(db, opts, function (err, multidat) {
+        t.ifError(err, 'no error')
+        multidat.create('/non/existing/path', function (err, dat) {
+          t.ok(err, 'error')
+          t.notOk(dat, 'no dat')
+        })
+      })
+    })
   })
 
   tape('worker=' + worker + ' multidat.list()', function (t) {


### PR DESCRIPTION
before, `multidat.create((err, dat))` wouldn't give us an error because our custom `createArchive` function passes an error as the `dat` argument, so `.list()` doesn't fail when there was an error creating an individual dat. Not the cleanest solution, but the cleanest without major changes to the library as I see. At least the outside interface is clean :)