### PR TITLE
(readme) update multidat.create parameter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Options:
 
 - `Dat`: Use provided dat factory instead of [dat-node](https://github.com/datproject/dat-node)
 
-### multidat.create(opts, callback(err, dat))
+### multidat.create(dir, opts, callback(err, dat))
 Create a new `dat` archive.
 
 ### dats = multidat.list()


### PR DESCRIPTION
The first parameter for `multidat.create` is dir, not opts: https://github.com/datproject/multidat/blob/master/index.js#L31